### PR TITLE
handle episode.index being empty

### DIFF
--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -88,7 +88,7 @@ class EpisodesPaginator(pagination.MCLPaginator):
             # selected episode in it
             episodes = []
             _amount = self.initialPageSize + self.orphans
-            epSeasonIndex = int(episode.index) - 1  # .index is 1-based
+            epSeasonIndex = int(episode.index or 1) - 1  # .index is 1-based
             if _amount < self.leafCount:
                 _amount = self.initialPageSize * 2
                 notFound = False


### PR DESCRIPTION
I've seen this happen for some episodes produced by Plex DVR.

Fixes this crash:
Error Type: <class 'ValueError'>
Error Contents: invalid literal for int() with base 10: ''
Traceback (most recent call last):
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/kodigui.py", line 105, in onInit
    self.onFirstInit()
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/episodes.py", line 261, in onFirstInit
    self._onFirstInit()
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/busy.py", line 20, in inner
    return func(*args, **kwargs)
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/episodes.py", line 252, in _onFirstInit
    self._setup()
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/episodes.py", line 307, in _setup
    self.fillEpisodes()
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/episodes.py", line 966, in fillEpisodes
    items = self.episodesPaginator.paginate()
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/pagination.py", line 191, in paginate
    items = self.initialPage
    File "/home/osmc/.kodi/addons/script.plex/lib/windows/episodes.py", line 91, in initialPage
    epSeasonIndex = int(episode.index) - 1  # .index is 1-based
ValueError: invalid literal for int() with base 10: ''

GHI (If applicable): #

## Description:

## Checklist:
- [ ] I have based this PR against the develop branch
